### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server that provides useful web development tools.
 
+<a href="https://glama.ai/mcp/servers/@ZukAi-MCP/webdev-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ZukAi-MCP/webdev-mcp/badge" alt="webdev-mcp MCP server" />
+</a>
+
 ## Usage
 
 ### Cursor
@@ -52,4 +56,3 @@ The tool will return the screenshot as a base64 encoded string.
 ## Tips
 
 Make sure YOLO mode is on and MCP tools protection is off in your Cursor settings for the best experience. You might have to allow Cursor to record your screen on MacOS.
-


### PR DESCRIPTION
This PR adds a badge for the [webdev-mcp](https://glama.ai/mcp/servers/@ZukAi-MCP/webdev-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ZukAi-MCP/webdev-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ZukAi-MCP/webdev-mcp/badge" alt="webdev-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.